### PR TITLE
Fix header buttons unclickable in fullscreen

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -323,11 +323,11 @@ const Header = ({ guild, channel }: { guild: Guild; channel: Channel; }) => {
     return (
         <HeaderBar
             toolbar={
-                <>
+                <div className="vc-sidebarchat-toolbar">
                     <HeaderBarIcon icon={ArrowsLeftRightIcon} tooltip="Switch channels" onClick={switchChannels} />
                     <HeaderBarIcon icon={WindowLaunchIcon} tooltip="Popout Chat" onClick={openPopout} />
                     <HeaderBarIcon icon={XSmallIcon} tooltip="Close Sidebar Chat" onClick={closeSidebar} />
-                </>
+                </div>
             }
         >
             <ChannelHeader

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,10 @@
 [class*="content"] > [class*="page"] > * {
     min-width: 0;
 }
+
+.vc-sidebarchat-toolbar {
+    -webkit-app-region: no-drag;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}


### PR DESCRIPTION
Custom title-bar CSS (e.g. visual-refresh-compact-title-bar) repositions Discord's window-drag region over the sidebar chat header. The toolbar's switch/popout/close icons weren't excluded from that drag region, so clicks got swallowed as window-drag once the layout shifted in fullscreen. Wraps the toolbar icons in a .vc-sidebarchat-toolbar div and sets -webkit-app-region: no-drag on it.